### PR TITLE
tsl/pack.mcmetaがGitHubの著作物になっていた問題を修正

### DIFF
--- a/tsl/pack.mcmeta
+++ b/tsl/pack.mcmeta
@@ -4,4 +4,3 @@
     "description": "Azisaba Network: TSL v1.0.0"
   }
 }
-© 2021 GitHub, Inc.


### PR DESCRIPTION
クライアントはこんなpack.mcmetaでも普通に読み込むらしい